### PR TITLE
Fixed: referenced before assignment when content is not specified

### DIFF
--- a/fcgi.py
+++ b/fcgi.py
@@ -19,6 +19,7 @@ def main():
     uri = parseResult.path
     query = parseResult.query
     client = FastCGIClient(host, port, 3000, 0)
+    content = ''
     if argc > 3:
         content = argvs[3]
     # content = "name=john&address=beijing"


### PR DESCRIPTION
The variable `content` might be used before initialization if `sys.argv[4]` is `None`.

POC:
```bash
$ python fcgi.py http://127.0.0.1:9000/index.php?a=b /var/www
Traceback (most recent call last):
  File "fcgi.py", line 46, in <module>
    main()
  File "fcgi.py", line 40, in main
    'CONTENT_LENGTH': len(content)
UnboundLocalError: local variable 'content' referenced before assignment
```